### PR TITLE
Allow Guzzle 7 (Laravel 8 requirement) & PHP 8. Tested in production since 8 Oct 2020

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     ],
     "require": {
         "php": "^7.4.0",
-        "guzzlehttp/guzzle": "^6.5.0",
+        "guzzlehttp/guzzle": "^6.5.0|^7.0",
         "psr/http-message": "^1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.0",
+        "php": "^7.4.0|^8.0",
         "guzzlehttp/guzzle": "^6.5.0|^7.0",
         "psr/http-message": "^1.0.0"
     },


### PR DESCRIPTION
Hi @Omranic and @Rowayda-Khayri 

Modified composer.json to allow allow guzzle 7 and now PHP 8.

**As for testing, I am running my own fork of it since October 8 2020 in production (PHP 7.4) and encountered no issues.**

As for laravel-notification-channels/authy and rinvex/laravel-authy

I will not be making PRs for them as my composer.json file load my forks in the repositories key. But you can refer to their require key contents at the following links and make your changes to laravel-notification-channels/authy and rinvex/laravel-authy. (Mostly to allow for installation on laravel 8 and allows Guzzle 7 and PHP 8)

https://github.com/ziming/authy/blob/master/composer.json (fork of laravel-notification-channels/authy)

https://github.com/ziming/laravel-authy/blob/master/composer.json (fork of rinvex/laravel-authy)

All are tested in production to be working since early October 2020 (PHP 7.4)